### PR TITLE
FIX Service Ports

### DIFF
--- a/logstash/templates/service-headless.yaml
+++ b/logstash/templates/service-headless.yaml
@@ -16,8 +16,4 @@ spec:
   selector:
     app: "{{ template "logstash.fullname" . }}"
   ports:
-  - name: http
-    port: {{ .Values.httpPort }}
-{{- if .Values.extraPorts }}
-{{- toYaml .Values.extraPorts | nindent 2 }}
-{{- end }}
+{{ toYaml .Values.service.ports | indent 4 }}


### PR DESCRIPTION
Ran into this when trying out your helm-3 PR version of Logstash.
extraPorts are used in the statefulset and as such are container port specifications. The headless service, just like the normal service needs to be .Values.service.ports, since those contain actual service specifications.
